### PR TITLE
The serializer now coerce BigDecimal to Double and Long, if possible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,8 @@ libraryDependencies <<= scalaVersion { scala_version =>
         "org.scalaz"           % "scalaz-effect"       % scalazVersion cross CrossVersion.full,
         "org.mongodb"          % "mongo-java-driver"   % "2.9.3",
         "io.spray"             % "spray-json"          % "1.2.2" cross CrossVersion.full,
-        "org.specs2"           % "specs2"              % "1.12.2" % "test"  cross CrossVersion.full
+        "org.specs2"           % "specs2"              % "1.12.2" % "test"  cross CrossVersion.full,
+        "org.scalacheck"       % "scalacheck"          % "1.10.0" % "test" cross CrossVersion.full
     )
 }
 

--- a/src/main/scala/org/cakesolutions/scalad/mongo/SprayJsonSupport.scala
+++ b/src/main/scala/org/cakesolutions/scalad/mongo/SprayJsonSupport.scala
@@ -109,10 +109,15 @@ object SprayJsonImplicits extends UuidChecker{
   }
 
   implicit val SprayJsonToDBObject = (jsValue: JsValue) => js2db(jsValue).asInstanceOf[DBObject]
-
   implicit val ObjectToSprayJson = (obj: DBObject) => obj2js(obj)
-
   implicit val SprayStringToDBObject = (json: String) => js2db(JsonParser.apply(json))
+}
+
+/**
+ * Mix this in to automatically get an implicit SprayJsonSerialisation in your scope
+ */
+trait SprayJsonSerializers {
+  implicit def sprayJsonSerializer[T: JsonFormat]: MongoSerializer[T] = new SprayJsonSerialisation[T]
 }
 
 /**

--- a/src/main/scala/org/cakesolutions/scalad/mongo/package.scala
+++ b/src/main/scala/org/cakesolutions/scalad/mongo/package.scala
@@ -34,7 +34,6 @@ trait MongoSerializer[T] {
   * Here is a good place to add an index.
   */
 trait CollectionProvider[T] {
-
   def getCollection: DBCollection
 }
 
@@ -71,7 +70,7 @@ trait IndexedCollectionProvider[T] extends CollectionProvider[T] {
   doIndex()
 
   def doIndex() {
-    import Implicits.JSON2DBObject
+    import Implicits._
     // TODO: complain if the index is not created, e.g. syntax error in `String`
     uniqueFields.foreach(field => getCollection.ensureIndex(field, null, true))
     indexFields.foreach(field => getCollection.ensureIndex(field, null, false))

--- a/src/test/scala/org/cakesolutions/scalad/mongo/SprayJsonSupportSpec.scala
+++ b/src/test/scala/org/cakesolutions/scalad/mongo/SprayJsonSupportSpec.scala
@@ -1,20 +1,20 @@
 package org.cakesolutions.scalad.mongo
 
 import com.mongodb._
+import java.util.UUID
 import org.specs2._
 import org.specs2.mutable.Specification
-import spray.json._
 import scala.collection.convert.WrapAsJava._
 import scala.collection.convert.WrapAsScala._
+import spray.json._
 
 case class JsValueEntity(value: JsValue)
 case class DoubleEntity(value: Double)
 
-class SprayJsonSupportTest extends Specification with DefaultJsonProtocol {
+class SprayJsonSupportTest extends Specification with DefaultJsonProtocol with UuidMarshalling {
 
   implicit val JsObjectEntityFormatter = jsonFormat1(JsValueEntity)
   implicit val DoubleEntityFormatter = jsonFormat1(DoubleEntity)
-
 
   def mustSerialize[T: JsonFormat](entity: T, expected: DBObject) {
       val serializer = new SprayJsonSerialisation[T]
@@ -80,6 +80,16 @@ class SprayJsonSupportTest extends Specification with DefaultJsonProtocol {
 
     "be able to deserialize a String" in {
       val original = Map("v" -> "hello")
+      mustDeserialize(new BasicDBObject(original), original)
+    }
+
+    "be able to serialize a UUID" in {
+      val original = Map("v" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
+      mustSerialize(original, new BasicDBObject(original))
+    }
+
+    "be able to deserialize a UUID" in {
+      val original = Map("v" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
       mustDeserialize(new BasicDBObject(original), original)
     }
 

--- a/src/test/scala/org/cakesolutions/scalad/mongo/mongodbtests.scala
+++ b/src/test/scala/org/cakesolutions/scalad/mongo/mongodbtests.scala
@@ -2,6 +2,8 @@ package org.cakesolutions.scalad.mongo
 
 import com.mongodb._
 import java.util.UUID
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
 import org.specs2.mutable.Specification
 import scala.math.BigInt.probablePrime
 import scala.util.Random
@@ -14,21 +16,6 @@ trait MongoCrudTestAccess {
   val db = m.getDB("MongoCrudTest")
   db.dropDatabase()
 }
-
-// might move upstream: https://github.com/spray/spray-json/issues/25
-trait UuidMarshalling {
-
-  implicit object UuidJsonFormat extends JsonFormat[UUID] {
-    def write(x: UUID) = JsString(x toString())
-
-    def read(value: JsValue) = value match {
-      case JsString(x) => UUID.fromString(x)
-      case x => deserializationError("Expected UUID as JsString, but got " + x)
-    }
-  }
-
-}
-
 
 case class LongEntity(id: Long, word: String)
 
@@ -187,4 +174,16 @@ class MongoCrudTest extends Specification with LongEntityPersistence with UuidEn
       crud.updateFirst(update).get mustEqual (update)
     }
   }
+}
+
+object StringSpec extends Properties("String") {
+  property("startsWith") = forAll((a: String, b: String) => (a+b).startsWith(a))
+
+  property("concatenate") = forAll((a: String, b: String) =>
+      (a+b).length > a.length && (a+b).length > b.length
+  )
+
+  property("substring") = forAll((a: String, b: String, c: String) =>
+      (a+b+c).substring(a.length, a.length+b.length) == b
+  )
 }

--- a/src/test/scala/org/cakesolutions/scalad/mongo/mongodbtests.scala
+++ b/src/test/scala/org/cakesolutions/scalad/mongo/mongodbtests.scala
@@ -176,6 +176,7 @@ class MongoCrudTest extends Specification with LongEntityPersistence with UuidEn
   }
 }
 
+//These tests are bogus one to explore ScalaCheck. Please ignore them for now.
 object StringSpec extends Properties("String") {
   property("startsWith") = forAll((a: String, b: String) => (a+b).startsWith(a))
 


### PR DESCRIPTION
Me and Sam have struggled a lot before realising this was the way to go. BigDecimal are not supported at all in MongoDB, and we also spotted a Scala bug in the process :dart: 
